### PR TITLE
Update typescript version and move it to dev-dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,9 +25,10 @@
       "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA=="
     },
     "typescript": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.0.1.tgz",
-      "integrity": "sha512-zQIMOmC+372pC/CCVLqnQ0zSBiY7HHodU7mpQdjiZddek4GMj31I3dUJ7gAs9o65X7mnRma6OokOkc6f9jjfBg=="
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.6.tgz",
+      "integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cod-api",
   "version": "4.0.0",
-  "description": "A Call of Duty Network API written in Node.js",
+  "description": "A Call of Duty Network API wrapper written in Typescript",
   "scripts": {
     "build": "tsc"
   },
@@ -38,12 +38,12 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "node-fetch": "^2.3.0",
-    "typescript": "^3.0.1"
+    "node-fetch": "^2.3.0"
   },
   "repository": "github:jakejrichards/cod-api",
   "readmeFilename": "README.md",
   "devDependencies": {
-    "@types/node-fetch": "^2.1.4"
+    "@types/node-fetch": "^2.1.4",
+    "typescript": "^3.1.0"
   }
 }


### PR DESCRIPTION
This PR updates typescript from version 3.0 -> 3.1 and moves it from the dependencies to the dev-dependencies. As pointed out in https://github.com/jakejrichards/cod-api/issues/12, typescript should most certainly be a dev-dependency.