### PR TITLE
Update BlackoutMatch in blackout.ts

### DIFF
--- a/blackout.ts
+++ b/blackout.ts
@@ -224,7 +224,7 @@ export interface BlackoutMatch {
     gameType: string;
     playerCount: number;
     playlistName: any;
-    playerStats: BaseStats;
+    playerStats: PlayerStats;
     draw: boolean;
     privateMatch: boolean;
 }


### PR DESCRIPTION
Based on the work I've been doing I believe the type of playerStats in BlackoutMatch should be PlayerStats rather than BaseStats.  I made this change in my local project and it's working correctly with live API calls.  Check it out and see what you think.